### PR TITLE
Export deploy info to env

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A simple script to deploy PHP applications in a few minutes to ElasticBeanstalk.
 ### Composer
 
 ```shell
-composer global require "leroy-merlin-br/dployer=*@dev"
+composer global require leroy-merlin-br/dployer"
 ```
 
 ## Global config for dployer
@@ -137,6 +137,51 @@ dployer deploy
     ]
 }
 ```
+
+### Runtime variables
+
+During deploy process, you may need to reuse some of the runtime parameters in your `.dployer` file. This parameters are exposed via environment variables so they can be accessed by your `.dployer` file steps.
+
+```
+EBS_APP = EBS Aplication name.
+EBS_ENV = EBS Environment name.
+GIT_BRANCH = Current git branch.
+GIT_COMMIT = Current git message.
+```
+
+In your `.dployer` you can trigger a notification scrpit with this env vars content:
+
+```json
+{
+    "application": "ApplicationName",
+    "environment": "my-environment",
+    "scripts": {
+        "init": "composer dumpautoload",
+        "before-pack": [
+            "gulp build --production"
+        ],
+        "before-deploy": [
+            "echo 'Deploying new version'",
+            "sh ./slack.sh start $EBS_APP $EBS_ENV",
+            "echo 'Another important command to run before deploy'"
+        ],
+        "finish": [
+            "gulp clean",
+            "sh ./slack.sh finish $EBS_APP $EBS_ENV",
+            "echo 'Nicely done'"
+        ]
+    },
+    "copy-paths": [
+        "vendor",
+        "public/assets"
+    ],
+    "exclude-paths": [
+        ".git",
+        "vendor/**/*.git"
+    ]
+}
+```
+
 ### Events
 
 Dployer triggers 4 events in deploy flow:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A simple script to deploy PHP applications in a few minutes to ElasticBeanstalk.
   - [Options](#options)
 - [Project Configuration](#project-configuration)
   - [Sample](#sample-dployer)
+  - [Runtime variables](#runtime-variables)
   - [Events](#events)
   - [copy-paths](#copy-paths)
   - [exclude-paths](#exclude-paths)
@@ -26,7 +27,7 @@ A simple script to deploy PHP applications in a few minutes to ElasticBeanstalk.
 ### Composer
 
 ```shell
-composer global require leroy-merlin-br/dployer"
+composer global require leroy-merlin-br/dployer
 ```
 
 ## Global config for dployer
@@ -43,7 +44,7 @@ You have 2 options to configure AWS:
 You must fill the following environment variables.
 
 - `DPLOYER_PROFILE` : Your profile's name in AWS.
-- `DPLOYER_REGION`  : Your region you want to deploy something.
+- `DPLOYER_REGION` : Your region you want to deploy something.
 - `DPLOYER_AWS_KEY` : Your secret AWS key.
 - `DPLOYER_AWS_SECRET` : Your secret AWS SECRET.
 
@@ -142,44 +143,32 @@ dployer deploy
 
 During deploy process, you may need to reuse some of the runtime parameters in your `.dployer` file. This parameters are exposed via environment variables so they can be accessed by your `.dployer` file steps.
 
-```
-EBS_APP = EBS Aplication name.
-EBS_ENV = EBS Environment name.
-GIT_BRANCH = Current git branch.
-GIT_COMMIT = Current git message.
-```
+
+ - `EBS_APP` : EBS Aplication name.
+ - `EBS_ENV` : EBS Environment name.
+ - `GIT_BRANCH` : Current git branch.
+ - `GIT_COMMIT` : Current git message.
+
 
 In your `.dployer` you can trigger a notification scrpit with this env vars content:
 
 ```json
-{
-    "application": "ApplicationName",
-    "environment": "my-environment",
-    "scripts": {
-        "init": "composer dumpautoload",
-        "before-pack": [
-            "gulp build --production"
-        ],
-        "before-deploy": [
-            "echo 'Deploying new version'",
-            "sh ./slack.sh start $EBS_APP $EBS_ENV",
-            "echo 'Another important command to run before deploy'"
-        ],
-        "finish": [
-            "gulp clean",
-            "sh ./slack.sh finish $EBS_APP $EBS_ENV",
-            "echo 'Nicely done'"
-        ]
-    },
-    "copy-paths": [
-        "vendor",
-        "public/assets"
+(...)
+"scripts": {
+    "init": "composer dumpautoload",
+    "before-pack": [
+        "gulp build --production"
     ],
-    "exclude-paths": [
-        ".git",
-        "vendor/**/*.git"
+    "before-deploy": [
+        "echo 'Deploying new version'",
+        "sh ./slack.sh start $EBS_APP $EBS_ENV",
+    ],
+    "finish": [
+        "sh ./slack.sh finish $EBS_APP $EBS_ENV",
+        "echo 'Nicely done'"
     ]
 }
+(...)
 ```
 
 ### Events

--- a/app/Dployer/Command/Deploy.php
+++ b/app/Dployer/Command/Deploy.php
@@ -129,6 +129,8 @@ class Deploy extends Command
         $branch = exec('echo $(git branch | sed -n -e \'s/^\* \(.*\)/\1/p\')');
         $commitMsg = exec('echo $(git log --format="%s" -n 1)');
 
+        $this->exportDeployInfoToEnv($app, $env, $branch, $commit);
+
         $output->writeln('<info>APP:</info>'.$app);
         $output->writeln('<info>ENV:</info>'.$env);
 
@@ -234,5 +236,23 @@ class Deploy extends Command
         } catch (ScriptErrorException $error) {
             exit('Aborting...');
         }
+    }
+
+    /**
+     * Export deploy configuration to env vars so they can be accessed
+     * inside .dployer file.
+     *
+     * @param string $app    EBS Aplication name.
+     * @param string $env    EBS Environment name.
+     * @param string $branch Current git branch.
+     * @param string $commit Current git message.
+     *
+     */
+    protected function exportDeployInfoToEnv($app, $env, $branch, $commit)
+    {
+        exec('export EBS_APP="'.$app.'"');
+        exec('export EBS_ENV="'.$env.'"');
+        exec('export GIT_BRANCH="'.$branch.'"');
+        exec('export GIT_COMMIT="'.$commit.'"');
     }
 }

--- a/app/Dployer/Command/Deploy.php
+++ b/app/Dployer/Command/Deploy.php
@@ -242,11 +242,10 @@ class Deploy extends Command
      * Export deploy configuration to env vars so they can be accessed
      * inside .dployer file.
      *
-     * @param string $app    EBS Aplication name.
-     * @param string $env    EBS Environment name.
-     * @param string $branch Current git branch.
-     * @param string $commit Current git message.
-     *
+     * @param string $app    EBS Aplication name
+     * @param string $env    EBS Environment name
+     * @param string $branch current git branch
+     * @param string $commit current git message
      */
     protected function exportDeployInfoToEnv($app, $env, $branch, $commit)
     {

--- a/app/Dployer/Event/ScriptRunner.php
+++ b/app/Dployer/Event/ScriptRunner.php
@@ -100,6 +100,7 @@ class ScriptRunner
 
             if (false === $this->helper->ask($this->input, $output, $question)) {
                 $output->writeln('Skipped!');
+
                 continue;
             }
 


### PR DESCRIPTION
Expose deploy runtime variables to env so that they can be accessible by `.dployer` steps.